### PR TITLE
Use secure maven repository URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <repository>
             <id>central</id>
             <name>Maven Central</name>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <releases>
                 <enabled>true</enabled>
                 <checksumPolicy>warn</checksumPolicy>
@@ -128,7 +128,7 @@
                 <checksumPolicy>warn</checksumPolicy>
                 <updatePolicy>always</updatePolicy>
             </releases>
-            <url>http://www.sparetimelabs.com/maven2</url>
+            <url>https://www.sparetimelabs.com/maven2</url>
         </repository>
         <repository>
             <id>sonatype.snapshots</id>


### PR DESCRIPTION
Mitigates 501 error from maven.org when resolving artefacts.
Additionally https upgrade for sparetimelabs.com is also included for sake of completeness.