### PR TITLE
Ensure ExecutorService is shutdown when app stops

### DIFF
--- a/src/main/java/com/kodedu/terminalfx/TerminalAppStarter.java
+++ b/src/main/java/com/kodedu/terminalfx/TerminalAppStarter.java
@@ -1,5 +1,6 @@
 package com.kodedu.terminalfx;
 
+import com.kodedu.terminalfx.helper.ThreadHelper;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
@@ -28,6 +29,7 @@ public class TerminalAppStarter extends Application {
 
     @Override
     public void stop() throws Exception {
+        ThreadHelper.stopExecutorService();
         Platform.exit();
         System.exit(0);
     }

--- a/src/main/java/com/kodedu/terminalfx/helper/ThreadHelper.java
+++ b/src/main/java/com/kodedu/terminalfx/helper/ThreadHelper.java
@@ -71,4 +71,11 @@ public class ThreadHelper {
             e.printStackTrace();
         }
     }
+
+    public static void stopExecutorService() {
+        if (!singleExecutorService.isShutdown()) {
+            singleExecutorService.shutdown();
+        }
+    }
+
 }


### PR DESCRIPTION
ThreadHelper's ExecutorService does not get shutdown when the application is stopped.

I created a new public static utility method in ThreadHelper that calls executorService.shutdown().
I called this new method in the TerminalAppStarter in the overridden JavaFX Application.stop() method.
This will ensure the ExecutorService is shutdown when JavaFX exits.